### PR TITLE
Include manage.py and static files in sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ ENV/
 *.sqlite3
 architect_config.yml
 /static/
+/architect/static_dist/
 /media/
 /node_modules/
 .sass-cache/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,14 @@
+include README.rst requirements/base.txt requirements/test.txt
+recursive-include architect/document *
+recursive-include architect/inventory *
+recursive-include architect/manager *
+recursive-include architect/monitor *
+recursive-include architect/repository *
+recursive-include architect/schemas *
+recursive-include architect/templates *
+recursive-include architect/templatetags *
+recursive-include architect/tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.pyc
+recursive-exclude * *.pyo
+recursive-exclude * *.orig

--- a/architect/bin/manage.py
+++ b/architect/bin/manage.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE",
+                          "architect.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
+    execute_from_command_line(sys.argv)

--- a/architect/settings.py
+++ b/architect/settings.py
@@ -146,7 +146,7 @@ MEDIA_ROOT = os.path.abspath(os.path.join(BASE_DIR, 'media'))
 MEDIA_URL = WEBROOT + 'media/'
 
 if STATIC_ROOT is None:
-    STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, 'static'))
+    STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, 'architect', 'static_dist'))
 
 if STATIC_URL is None:
     STATIC_URL = WEBROOT + 'static/'
@@ -259,6 +259,17 @@ STATICFILES_FINDERS = (
     # 'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
+
+NPM_FILE_PATTERNS = {
+    'bootstrap': ['scss/*', 'dist/js/bootstrap.js'],
+    'bootstrap-notify': ['bootstrap-notify.js'],
+    'bootswatch': ['dist/cyborg/*', 'dist/materia/*', 'dist/united/*'],
+    'd3': ['build/d3.js'],
+    'font-awesome': ['scss/*', 'fonts/*'],
+    'jquery': ['dist/jquery.js'],
+    'jquery-form': ['src/jquery.form.js'],
+    'timeago': ['jquery.timeago.js']
+}
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ with open('./requirements/test.txt') as _tests_requirements:
 
 DESCRIPTION = "architect-api is a server API and UI of Architect, the service modeling, management and visualization platform."
 
-
 setup(
     name='architect-api',
     version=VERSION,
@@ -26,6 +25,7 @@ setup(
     license='Apache License, Version 2.0',
     url='https://github.com/cznewt/architect-api/',
     packages=find_packages(),
+    include_package_data=True,
     install_requires=requirements,
     tests_require=tests_requirements,
     extras_require={


### PR DESCRIPTION
Changes in this PR:
- `NPM_FILE_PATTERNS` defined to include only specified files from `node_modules` during `collectstatic`
- manage.py copied to `architect/bin/manage.py` so its accessible in architect-api installed by pip
- `STATIC_ROOT` default changed to `architect/static_dist` so its accessible in architect-api installed by pip
- `MANIFEST.in` file added to specify included modules and static files
